### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-pryrepl.org


### PR DESCRIPTION
since pryrepl.org is no longer accessible, we should remove the CNAME so that this site is up at http://pry.github.io/